### PR TITLE
Improve run instructions and allow direct execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ pip install tkcalendar
 
 ## 运行
 
+在安装好依赖后，脚本即可直接启动。建议先为文件添加可执行权限：
+
 ```bash
-python3 calendar_notes.py
+chmod +x calendar_notes.py
+./calendar_notes.py
 ```
 
 程序启动后会在顶部显示当前日期，点击 **选择日期** 按钮可弹出日历。日历中每个有笔记的日期下方都会显示带颜色的数字提示。选择日期后在下方的标签页中编辑笔记即可，内容会自动保存，无需额外的保存按钮。

--- a/calendar_notes.py
+++ b/calendar_notes.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 重构版日历笔记程序（增删改完善）


### PR DESCRIPTION
## Summary
- make `calendar_notes.py` directly executable by adding a shebang
- update run instructions in `README.md` to show using executable bit

## Testing
- `python3 calendar_notes.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_6876c37f849c8320b785f6d60476f22c